### PR TITLE
Add TS window declaration for TabContainerElement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,6 @@ export default class TabContainerElement extends HTMLElement { }
 
 declare global {
   interface Window {
-    TabContainerElement: TabContainerElement
+    TabContainerElement: typeof TabContainerElement
   }
 }


### PR DESCRIPTION
The TypeScript definition is incomplete as it doesn't properly reflect the assignment to Window.

This PR adds the declaration of `TabContainerElement` to the global window object, as that mutation is happening within the code and so should be reflected in the types.

 Refs https://github.com/github/application-architecture/issues/58