### PR TITLE
Make sure non-active tabs have a -1 in tabindex

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ import '@github/tab-container-element'
 <tab-container>
   <div role="tablist">
     <button type="button" role="tab" aria-selected="true">Tab one</button>
-    <button type="button" role="tab">Tab two</button>
-    <button type="button" role="tab">Tab three</button>
+    <button type="button" role="tab" tabindex="-1">Tab two</button>
+    <button type="button" role="tab" tabindex="-1">Tab three</button>
   </div>
   <div role="tabpanel">
     Panel 1

--- a/examples/index.html
+++ b/examples/index.html
@@ -9,8 +9,8 @@
   <tab-container>
     <div role="tablist">
       <button type="button" role="tab" aria-selected="true">Tab one</button>
-      <button type="button" role="tab">Tab two</button>
-      <button type="button" role="tab">Tab three</button>
+      <button type="button" role="tab" tabindex="-1">Tab two</button>
+      <button type="button" role="tab" tabindex="-1">Tab three</button>
     </div>
     <div role="tabpanel">
       Panel 1


### PR DESCRIPTION
The initial HTML should have `tabindex="-1"` on tabs that are not active so you can't tab to them since users should use the arrow keys to navigate the tabs.

Fixes https://github.com/github/tab-container-element/issues/20.
