### PR TITLE
Don't set `tabindex` on panels

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ function selectTab(tabContainer: TabContainerElement, index: number) {
 
   for (const tab of tabs) {
     tab.setAttribute('aria-selected', 'false')
+    tab.setAttribute('tabindex', '-1')
   }
   for (const panel of panels) {
     panel.hidden = true

--- a/index.js
+++ b/index.js
@@ -63,6 +63,9 @@ function selectTab(tabContainer: TabContainerElement, index: number) {
   }
   for (const panel of panels) {
     panel.hidden = true
+    if (!panel.hasAttribute('data-tab-container-no-tabstop')) {
+      panel.setAttribute('tabindex', '0')
+    }
   }
 
   selectedTab.setAttribute('aria-selected', 'true')

--- a/index.js
+++ b/index.js
@@ -59,11 +59,9 @@ function selectTab(tabContainer: TabContainerElement, index: number) {
 
   for (const tab of tabs) {
     tab.setAttribute('aria-selected', 'false')
-    tab.setAttribute('tabindex', '-1')
   }
   for (const panel of panels) {
     panel.hidden = true
-    panel.setAttribute('tabindex', '0')
   }
 
   selectedTab.setAttribute('aria-selected', 'true')

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function selectTab(tabContainer: TabContainerElement, index: number) {
   }
   for (const panel of panels) {
     panel.hidden = true
-    if (!panel.hasAttribute('data-tab-container-no-tabstop')) {
+    if (!panel.hasAttribute('tabindex') && !panel.hasAttribute('data-tab-container-no-tabstop')) {
       panel.setAttribute('tabindex', '0')
     }
   }

--- a/test/test.js
+++ b/test/test.js
@@ -26,7 +26,7 @@ describe('tab-container', function() {
         <div role="tabpanel" hidden>
           Panel 2
         </div>
-        <div role="tabpanel" hidden>
+        <div role="tabpanel" hidden data-tab-container-no-tabstop>
           Panel 3
         </div>
       </tab-container>
@@ -92,6 +92,17 @@ describe('tab-container', function() {
 
       // The event listener should have been called.
       assert.equal(counter, 1)
+    })
+
+    it("panels that don't have a `data-tab-container-no-tabstop` attribute have tabindex with value '0'", function() {
+      const tabs = document.querySelectorAll('button')
+      const panels = document.querySelectorAll('[role="tabpanel"]')
+
+      tabs[1].click()
+
+      assert.equal(panels[0].getAttribute('tabindex'), '0')
+      assert.equal(panels[1].getAttribute('tabindex'), '0')
+      assert(!panels[2].hasAttribute('tabindex'))
     })
   })
 })


### PR DESCRIPTION
From internal issue:

>[...] a tabindex on the full panel is really only appropriate when it entirely consists of text (or the panel is large and the next focusable element is way down in the DOM). But even then, a heading with a tabindex is usually better than a full panel with one.

Ref: https://github.com/github/github/issues/137001