### PR TITLE
Pass original event with custom element

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,16 +17,16 @@ export default class TabContainerElement extends HTMLElement {
       if (event.code === 'ArrowRight') {
         let index = currentIndex + 1
         if (index >= tabs.length) index = 0
-        selectTab(this, index)
+        selectTab(this, index, event)
       } else if (event.code === 'ArrowLeft') {
         let index = currentIndex - 1
         if (index < 0) index = tabs.length - 1
-        selectTab(this, index)
+        selectTab(this, index, event)
       } else if (event.code === 'Home') {
-        selectTab(this, 0)
+        selectTab(this, 0, event)
         event.preventDefault()
       } else if (event.code === 'End') {
-        selectTab(this, tabs.length - 1)
+        selectTab(this, tabs.length - 1, event)
         event.preventDefault()
       }
     })
@@ -39,7 +39,7 @@ export default class TabContainerElement extends HTMLElement {
       if (!tab || !tab.closest('[role="tablist"]')) return
 
       const index = tabs.indexOf(tab)
-      selectTab(this, index)
+      selectTab(this, index, event)
     })
   }
 
@@ -59,7 +59,7 @@ export default class TabContainerElement extends HTMLElement {
   }
 }
 
-function selectTab(tabContainer: TabContainerElement, index: number) {
+function selectTab(tabContainer: TabContainerElement, index: number, originalEvent: MouseEvent | KeyboardEvent) {
   const tabs = tabContainer.querySelectorAll<HTMLElement>('[role="tablist"] [role="tab"]')
   const panels = tabContainer.querySelectorAll<HTMLElement>('[role="tabpanel"]')
 
@@ -94,7 +94,7 @@ function selectTab(tabContainer: TabContainerElement, index: number) {
   tabContainer.dispatchEvent(
     new CustomEvent('tab-container-changed', {
       bubbles: true,
-      detail: {relatedTarget: selectedPanel}
+      detail: {relatedTarget: selectedPanel, originalEvent}
     })
   )
 }

--- a/test/test.js
+++ b/test/test.js
@@ -127,5 +127,25 @@ describe('tab-container', function() {
       assert.equal(tabs[1].getAttribute('tabindex'), '0')
       assert.equal(tabs[0].getAttribute('tabindex'), '-1')
     })
+
+    it('clicking a tab dispatches a MouseEvent', function(done) {
+      const tabContainer = document.querySelector('tab-container')
+      const tabs = document.querySelectorAll('button')
+      tabContainer.addEventListener('tab-container-changed', event => {
+        done(assert.instanceOf(event.detail.originalEvent, MouseEvent))
+      })
+
+      tabs[1].click()
+    })
+
+    it('selecting a with the keyboard dispatches a KeyboardEvent', function(done) {
+      const tabContainer = document.querySelector('tab-container')
+      const tabs = document.querySelectorAll('button')
+      tabContainer.addEventListener('tab-container-changed', event => {
+        done(assert.instanceOf(event.detail.originalEvent, KeyboardEvent))
+      })
+
+      tabs[0].dispatchEvent(new KeyboardEvent('keydown', {code: 'ArrowLeft', bubbles: true}))
+    })
   })
 })


### PR DESCRIPTION
This change passes the original `MouseEvent` or `KeyboardEvent` in the `CustomEvent` that is dispatched on `tab-container-changed`. It will make it possible for the application code to make decisions based on wether the user clicked a tab or navigated to it with their keyboard.

It might be overkill to send the whole event, we might get away with just sending the `typeof` of the event but I felt like doing string matching on the application side was a bit yucky. Being able to do a `instanceof` check seems a bit cleaner. I'd be interested in your thoughts.

Ref: https://github.com/github/github/issues/133906