### PR TITLE
Add type='module' to script tag

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -23,7 +23,7 @@
     </div>
   </tab-container>
 
-  <!-- <script src="../dist/index.umd.js"></script> -->
-  <script src="https://unpkg.com/@github/tab-container-element@latest/dist/index.umd.js"></script>
+  <!-- <script src="../dist/index.js" type="module"></script> -->
+  <script src="https://unpkg.com/@github/tab-container-element@latest/dist/index.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
as moving to typescript #25  and removing babel we don't need `.umd` anymore so:
- Removing `.umd` from script tag to point to the valid build file.
- Adding `type=module` to make the example works on modern browsers at least.

testing note: 
Adding `type=module` to script will lead you to CORS issue if you run `examples/index.html` locally. you need to run it through a server.