### PR TITLE
fix: only hide tab panels and set aria-selected of closest tab-container

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export default class TabContainerElement extends HTMLElement {
       if (!(target instanceof HTMLElement)) return
       if (target.closest(this.tagName) !== this) return
       if (target.getAttribute('role') !== 'tab' && !target.closest('[role="tablist"]')) return
-      const tabs = Array.from(this.querySelectorAll('[role="tablist"] [role="tab"]'))
+      const tabs = Array.from(this.querySelectorAll('[role="tablist"] [role="tab"]')).filter(tab => tab.closest(this.tagName) === this)
       const currentIndex = tabs.indexOf(tabs.find(tab => tab.matches('[aria-selected="true"]'))!)
 
       if (event.code === 'ArrowRight') {
@@ -58,8 +58,8 @@ export default class TabContainerElement extends HTMLElement {
 }
 
 function selectTab(tabContainer: TabContainerElement, index: number) {
-  const tabs = tabContainer.querySelectorAll<HTMLElement>('[role="tablist"] [role="tab"]')
-  const panels = tabContainer.querySelectorAll<HTMLElement>('[role="tabpanel"]')
+  const tabs = Array.from(tabContainer.querySelectorAll<HTMLElement>('[role="tablist"] [role="tab"]')).filter(tab => tab.closest(tabContainer.tagName) === tabContainer)
+  const panels = Array.from(tabContainer.querySelectorAll<HTMLElement>('[role="tabpanel"]')).filter(panel => panel.closest(tabContainer.tagName) === tabContainer)
 
   const selectedTab = tabs[index]
   const selectedPanel = panels[index]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
+function getTabs(el: TabContainerElement): HTMLElement[] {
+  return Array.from(el.querySelectorAll<HTMLElement>('[role="tablist"] [role="tab"]')).filter(
+    tab => tab instanceof HTMLElement && tab.closest(el.tagName) === el
+  )
+}
+
 export default class TabContainerElement extends HTMLElement {
   constructor() {
     super()
@@ -7,9 +13,7 @@ export default class TabContainerElement extends HTMLElement {
       if (!(target instanceof HTMLElement)) return
       if (target.closest(this.tagName) !== this) return
       if (target.getAttribute('role') !== 'tab' && !target.closest('[role="tablist"]')) return
-      const tabs = Array.from(this.querySelectorAll('[role="tablist"] [role="tab"]')).filter(
-        tab => tab.closest(this.tagName) === this
-      )
+      const tabs = getTabs(this)
       const currentIndex = tabs.indexOf(tabs.find(tab => tab.matches('[aria-selected="true"]'))!)
 
       if (event.code === 'ArrowRight') {
@@ -30,13 +34,13 @@ export default class TabContainerElement extends HTMLElement {
     })
 
     this.addEventListener('click', (event: MouseEvent) => {
-      const tabs = Array.from(this.querySelectorAll('[role="tablist"] [role="tab"]'))
+      const tabs = getTabs(this)
 
       if (!(event.target instanceof Element)) return
       if (event.target.closest(this.tagName) !== this) return
 
       const tab = event.target.closest('[role="tab"]')
-      if (!tab || !tab.closest('[role="tablist"]')) return
+      if (!(tab instanceof HTMLElement) || !tab.closest('[role="tablist"]')) return
 
       const index = tabs.indexOf(tab)
       selectTab(this, index)
@@ -44,7 +48,7 @@ export default class TabContainerElement extends HTMLElement {
   }
 
   connectedCallback(): void {
-    for (const tab of this.querySelectorAll('[role="tablist"] [role="tab"]')) {
+    for (const tab of getTabs(this)) {
       if (!tab.hasAttribute('aria-selected')) {
         tab.setAttribute('aria-selected', 'false')
       }
@@ -60,9 +64,7 @@ export default class TabContainerElement extends HTMLElement {
 }
 
 function selectTab(tabContainer: TabContainerElement, index: number) {
-  const tabs = Array.from(tabContainer.querySelectorAll<HTMLElement>('[role="tablist"] [role="tab"]')).filter(
-    tab => tab.closest(tabContainer.tagName) === tabContainer
-  )
+  const tabs = getTabs(tabContainer)
   const panels = Array.from(tabContainer.querySelectorAll<HTMLElement>('[role="tabpanel"]')).filter(
     panel => panel.closest(tabContainer.tagName) === tabContainer
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,9 @@ export default class TabContainerElement extends HTMLElement {
       if (!(target instanceof HTMLElement)) return
       if (target.closest(this.tagName) !== this) return
       if (target.getAttribute('role') !== 'tab' && !target.closest('[role="tablist"]')) return
-      const tabs = Array.from(this.querySelectorAll('[role="tablist"] [role="tab"]')).filter(tab => tab.closest(this.tagName) === this)
+      const tabs = Array.from(this.querySelectorAll('[role="tablist"] [role="tab"]')).filter(
+        tab => tab.closest(this.tagName) === this
+      )
       const currentIndex = tabs.indexOf(tabs.find(tab => tab.matches('[aria-selected="true"]'))!)
 
       if (event.code === 'ArrowRight') {
@@ -58,8 +60,12 @@ export default class TabContainerElement extends HTMLElement {
 }
 
 function selectTab(tabContainer: TabContainerElement, index: number) {
-  const tabs = Array.from(tabContainer.querySelectorAll<HTMLElement>('[role="tablist"] [role="tab"]')).filter(tab => tab.closest(tabContainer.tagName) === tabContainer)
-  const panels = Array.from(tabContainer.querySelectorAll<HTMLElement>('[role="tabpanel"]')).filter(panel => panel.closest(tabContainer.tagName) === tabContainer)
+  const tabs = Array.from(tabContainer.querySelectorAll<HTMLElement>('[role="tablist"] [role="tab"]')).filter(
+    tab => tab.closest(tabContainer.tagName) === tabContainer
+  )
+  const panels = Array.from(tabContainer.querySelectorAll<HTMLElement>('[role="tabpanel"]')).filter(
+    panel => panel.closest(tabContainer.tagName) === tabContainer
+  )
 
   const selectedTab = tabs[index]
   const selectedPanel = panels[index]

--- a/test/test.js
+++ b/test/test.js
@@ -177,6 +177,10 @@ describe('tab-container', function () {
       assert.deepStrictEqual(nestedTabs.map(isSelected), [false, true], 'nested tabs did change state')
       assert.deepStrictEqual(panels.map(isHidden), [false, true, true], 'top panels changed state')
       assert.deepStrictEqual(nestedPanels.map(isHidden), [true, false], 'nested panels did not change state')
+
+      tabs[1].click()
+
+      assert.deepStrictEqual(nestedPanels.map(isHidden), [true, false], 'nested panels did change state')
     })
 
     it('only switches closest tab-containers on arrow', () => {
@@ -198,6 +202,11 @@ describe('tab-container', function () {
       assert.deepStrictEqual(nestedTabs.map(isSelected), [false, true], 'nested tabs did change state')
       assert.deepStrictEqual(panels.map(isHidden), [false, true, true], 'top panels changed state')
       assert.deepStrictEqual(nestedPanels.map(isHidden), [true, false], 'nested panels did not change state')
+      
+      tabs[1].dispatchEvent(new KeyboardEvent('keydown', {code: 'ArrowLeft', bubbles: true}))
+      
+      assert.deepStrictEqual(nestedPanels.map(isHidden), [true, false], 'nested panels changed state when top panel changed')
+      assert.deepStrictEqual(nestedTabs.map(isSelected), [false, true], 'nested tabs changed state when top panel changed')
     })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -202,11 +202,19 @@ describe('tab-container', function () {
       assert.deepStrictEqual(nestedTabs.map(isSelected), [false, true], 'nested tabs did change state')
       assert.deepStrictEqual(panels.map(isHidden), [false, true, true], 'top panels changed state')
       assert.deepStrictEqual(nestedPanels.map(isHidden), [true, false], 'nested panels did not change state')
-      
+
       tabs[1].dispatchEvent(new KeyboardEvent('keydown', {code: 'ArrowLeft', bubbles: true}))
-      
-      assert.deepStrictEqual(nestedPanels.map(isHidden), [true, false], 'nested panels changed state when top panel changed')
-      assert.deepStrictEqual(nestedTabs.map(isSelected), [false, true], 'nested tabs changed state when top panel changed')
+
+      assert.deepStrictEqual(
+        nestedPanels.map(isHidden),
+        [true, false],
+        'nested panels changed state when top panel changed'
+      )
+      assert.deepStrictEqual(
+        nestedTabs.map(isSelected),
+        [false, true],
+        'nested tabs changed state when top panel changed'
+      )
     })
   })
 })


### PR DESCRIPTION
Thanks for the original fix to #30, but there were still some issues. Notably, nested panels were hidden when a top tab was clicked. 

I also tried to fix the keyboard navigation issues, but I'm not sure it's correct.