### PR TITLE
Ensure that panels have associated label in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ import '@github/tab-container-element'
 ```html
 <tab-container>
   <div role="tablist">
-    <button type="button" role="tab" aria-selected="true">Tab one</button>
-    <button type="button" role="tab" tabindex="-1">Tab two</button>
-    <button type="button" role="tab" tabindex="-1">Tab three</button>
+    <button type="button" id="tab-one" role="tab" aria-selected="true">Tab one</button>
+    <button type="button" id="tab-two" role="tab" tabindex="-1">Tab two</button>
+    <button type="button" id="tab-three"role="tab" tabindex="-1">Tab three</button>
   </div>
-  <div role="tabpanel">
+  <div role="tabpanel" aria-labelledby="tab-one">
     Panel 1
   </div>
-  <div role="tabpanel" hidden>
+  <div role="tabpanel" aria-labelledby="tab-two" hidden>
     Panel 2
   </div>
-  <div role="tabpanel" hidden>
+  <div role="tabpanel" aria-labelledby="tab-three" hidden>
     Panel 3
   </div>
 </tab-container>

--- a/examples/index.html
+++ b/examples/index.html
@@ -8,17 +8,17 @@
 <body>
   <tab-container>
     <div role="tablist">
-      <button type="button" role="tab" tabindex="0" aria-selected="true">Tab one</button>
-      <button type="button" role="tab" tabindex="-1">Tab two</button>
-      <button type="button" role="tab" tabindex="-1">Tab three</button>
+      <button type="button" id="tab-one" role="tab" tabindex="0" aria-selected="true">Tab one</button>
+      <button type="button" id="tab-two" role="tab" tabindex="-1">Tab two</button>
+      <button type="button" id="tab-three" role="tab" tabindex="-1">Tab three</button>
     </div>
-    <div role="tabpanel">
+    <div role="tabpanel" aria-labelledby="tab-one">
       Panel 1
     </div>
-    <div role="tabpanel" hidden>
+    <div role="tabpanel" aria-labelledby="tab-two" hidden>
       Panel 2
     </div>
-    <div role="tabpanel" hidden>
+    <div role="tabpanel" aria-labelledby="tab-three" hidden>
       Panel 3
     </div>
   </tab-container>


### PR DESCRIPTION
This PR updates the examples to ensure that each of the `tabpanel` elements are associated with a label per WAI-ARIA doc recommendations.

According to [WAI-ARIA authoring practices for Tab](https://www.w3.org/TR/wai-aria-practices/#tabpanel):

> If the tab list has a visible label, the element with role tablist has aria-labelledby set to a value that refers to the labelling element. Otherwise, the tablist element has a label provided by aria-label.

This follows the pattern shown in [Example of Tabs with Automatic Activation](https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-1/tabs.html). 