### PR TITLE
Support `[aria-orientation="vertical"]`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 type IncrementKey = 'ArrowRight' | 'ArrowDown'
 type DecrementKey = 'ArrowUp' | 'ArrowLeft'
-type NavigationDirection = [IncrementKey, DecrementKey]
 
 function getTabs(el: TabContainerElement): HTMLElement[] {
   return Array.from(el.querySelectorAll<HTMLElement>('[role="tablist"] [role="tab"]')).filter(
@@ -8,7 +7,7 @@ function getTabs(el: TabContainerElement): HTMLElement[] {
   )
 }
 
-function getNavigationKeys(vertical: boolean): NavigationDirection {
+function getNavigationKeys(vertical: boolean): [IncrementKey, DecrementKey] {
   if (vertical) {
     return ['ArrowDown', 'ArrowUp']
   } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,19 @@
+type IncrementKey = 'ArrowRight' | 'ArrowDown'
+type DecrementKey = 'ArrowUp' | 'ArrowLeft'
+type NavigationDirection = [IncrementKey, DecrementKey]
+
 function getTabs(el: TabContainerElement): HTMLElement[] {
   return Array.from(el.querySelectorAll<HTMLElement>('[role="tablist"] [role="tab"]')).filter(
     tab => tab instanceof HTMLElement && tab.closest(el.tagName) === el
   )
+}
+
+function getNavigationKeys(vertical: boolean): NavigationDirection {
+  if (vertical) {
+    return ['ArrowDown', 'ArrowUp']
+  } else {
+    return ['ArrowRight', 'ArrowLeft']
+  }
 }
 
 export default class TabContainerElement extends HTMLElement {
@@ -15,12 +27,15 @@ export default class TabContainerElement extends HTMLElement {
       if (target.getAttribute('role') !== 'tab' && !target.closest('[role="tablist"]')) return
       const tabs = getTabs(this)
       const currentIndex = tabs.indexOf(tabs.find(tab => tab.matches('[aria-selected="true"]'))!)
+      const [incrementKey, decrementKey] = getNavigationKeys(
+        !!target.closest('[role="tablist"][aria-orientation="vertical"]')
+      )
 
-      if (event.code === 'ArrowRight') {
+      if (event.code === incrementKey) {
         let index = currentIndex + 1
         if (index >= tabs.length) index = 0
         selectTab(this, index)
-      } else if (event.code === 'ArrowLeft') {
+      } else if (event.code === decrementKey) {
         let index = currentIndex - 1
         if (index < 0) index = tabs.length - 1
         selectTab(this, index)

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export default class TabContainerElement extends HTMLElement {
       const tabs = getTabs(this)
       const currentIndex = tabs.indexOf(tabs.find(tab => tab.matches('[aria-selected="true"]'))!)
       const [incrementKey, decrementKey] = getNavigationKeys(
-        !!(target.closest('[role="tablist"]')?.getAttribute('aria-orientation') === 'vertical')
+        target.closest('[role="tablist"]')?.getAttribute('aria-orientation') === 'vertical'
       )
 
       if (event.code === incrementKey) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export default class TabContainerElement extends HTMLElement {
       const tabs = getTabs(this)
       const currentIndex = tabs.indexOf(tabs.find(tab => tab.matches('[aria-selected="true"]'))!)
       const [incrementKey, decrementKey] = getNavigationKeys(
-        !!target.closest('[role="tablist"][aria-orientation="vertical"]')
+        !!(target.closest('[role="tablist"]')?.getAttribute('aria-orientation') === 'vertical')
       )
 
       if (event.code === incrementKey) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-type IncrementKey = 'ArrowRight' | 'ArrowDown'
-type DecrementKey = 'ArrowUp' | 'ArrowLeft'
+type IncrementKeyCode = 'ArrowRight' | 'ArrowDown'
+type DecrementKeyCode = 'ArrowUp' | 'ArrowLeft'
 
 function getTabs(el: TabContainerElement): HTMLElement[] {
   return Array.from(el.querySelectorAll<HTMLElement>('[role="tablist"] [role="tab"]')).filter(
@@ -7,11 +7,14 @@ function getTabs(el: TabContainerElement): HTMLElement[] {
   )
 }
 
-function getNavigationKeys(vertical: boolean): [IncrementKey, DecrementKey] {
+function getNavigationKeyCodes(vertical: boolean): [IncrementKeyCode[], DecrementKeyCode[]] {
   if (vertical) {
-    return ['ArrowDown', 'ArrowUp']
+    return [
+      ['ArrowDown', 'ArrowRight'],
+      ['ArrowUp', 'ArrowLeft']
+    ]
   } else {
-    return ['ArrowRight', 'ArrowLeft']
+    return [['ArrowRight'], ['ArrowLeft']]
   }
 }
 
@@ -26,15 +29,15 @@ export default class TabContainerElement extends HTMLElement {
       if (target.getAttribute('role') !== 'tab' && !target.closest('[role="tablist"]')) return
       const tabs = getTabs(this)
       const currentIndex = tabs.indexOf(tabs.find(tab => tab.matches('[aria-selected="true"]'))!)
-      const [incrementKey, decrementKey] = getNavigationKeys(
+      const [incrementKeys, decrementKeys] = getNavigationKeyCodes(
         target.closest('[role="tablist"]')?.getAttribute('aria-orientation') === 'vertical'
       )
 
-      if (event.code === incrementKey) {
+      if (incrementKeys.some(code => event.code === code)) {
         let index = currentIndex + 1
         if (index >= tabs.length) index = 0
         selectTab(this, index)
-      } else if (event.code === decrementKey) {
+      } else if (decrementKeys.some(code => event.code === code)) {
         let index = currentIndex - 1
         if (index < 0) index = tabs.length - 1
         selectTab(this, index)

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line import/no-commonjs, @typescript-eslint/no-var-requires
+// eslint-disable-next-line filenames/match-regex, import/no-commonjs, @typescript-eslint/no-var-requires
 process.env.CHROME_BIN = require('chromium').path
 
 // eslint-disable-next-line import/no-commonjs

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -1,4 +1,4 @@
-// eslint-disable-next-line filenames/match-regex, import/no-commonjs, @typescript-eslint/no-var-requires
+// eslint-disable-next-line import/no-commonjs, @typescript-eslint/no-var-requires
 process.env.CHROME_BIN = require('chromium').path
 
 // eslint-disable-next-line import/no-commonjs

--- a/test/test.js
+++ b/test/test.js
@@ -275,7 +275,7 @@ describe('tab-container', function () {
       assert.equal(counter, 2)
     })
 
-    it('does not supports left and right keyboard shortcuts', () => {
+    it('does not support left and right keyboard shortcuts', () => {
       const tabContainer = document.querySelector('tab-container')
       const tabs = document.querySelectorAll('button')
       const panels = document.querySelectorAll('[role="tabpanel"]')

--- a/test/test.js
+++ b/test/test.js
@@ -75,7 +75,7 @@ describe('tab-container', function () {
       assert.equal(counter, 2)
     })
 
-    it('does not support down and up keyboard shortcuts', () => {
+    it('down and up keyboard shortcuts do not work and `tab-container-changed` events are not dispatched', () => {
       const tabContainer = document.querySelector('tab-container')
       const tabs = document.querySelectorAll('button')
       const panels = document.querySelectorAll('[role="tabpanel"]')
@@ -86,14 +86,14 @@ describe('tab-container', function () {
       assert(!panels[0].hidden)
       assert(panels[1].hidden)
       assert(panels[2].hidden)
-      assert.equal(document.activeElement, tabs[0])
+      assert.equal(document.activeElement, document.body)
       assert.equal(counter, 0)
 
       tabs[0].dispatchEvent(new KeyboardEvent('keydown', {code: 'ArrowUp', bubbles: true}))
       assert(!panels[0].hidden)
       assert(panels[1].hidden)
       assert(panels[2].hidden)
-      assert.equal(document.activeElement, tabs[0])
+      assert.equal(document.activeElement, document.body)
       assert.equal(counter, 0)
     })
 
@@ -266,7 +266,7 @@ describe('tab-container', function () {
       `
     })
 
-    it('supports up and down keyboard shortcuts', () => {
+    it('up and down keyboard shortcuts work and `tab-container-changed` events are dispatched', () => {
       const tabContainer = document.querySelector('tab-container')
       const tabs = document.querySelectorAll('button')
       const panels = document.querySelectorAll('[role="tabpanel"]')
@@ -282,23 +282,22 @@ describe('tab-container', function () {
       assert(!panels[0].hidden)
       assert(panels[2].hidden)
       assert.equal(document.activeElement, tabs[0])
-      assert.equal(counter, 2)
 
       tabs[0].dispatchEvent(new KeyboardEvent('keydown', {code: 'ArrowDown', bubbles: true}))
       assert(panels[0].hidden)
       assert(!panels[1].hidden)
       assert(panels[2].hidden)
-      assert.equal(document.activeElement, panels[1])
+      assert.equal(document.activeElement, tabs[1])
 
       tabs[1].dispatchEvent(new KeyboardEvent('keydown', {code: 'End', bubbles: true}))
       assert(panels[0].hidden)
       assert(panels[1].hidden)
       assert(!panels[2].hidden)
       assert.equal(document.activeElement, tabs[2])
-      assert.equal(counter, 2)
+      assert.equal(counter, 4)
     })
 
-    it('supports left and right keyboard shortcuts', () => {
+    it('left and right keyboard shortcuts work and `tab-container-changed` events are dispatched', () => {
       const tabContainer = document.querySelector('tab-container')
       const tabs = document.querySelectorAll('button')
       const panels = document.querySelectorAll('[role="tabpanel"]')
@@ -314,20 +313,19 @@ describe('tab-container', function () {
       assert(!panels[0].hidden)
       assert(panels[2].hidden)
       assert.equal(document.activeElement, tabs[0])
-      assert.equal(counter, 2)
 
       tabs[0].dispatchEvent(new KeyboardEvent('keydown', {code: 'ArrowRight', bubbles: true}))
       assert(panels[0].hidden)
       assert(!panels[1].hidden)
       assert(panels[2].hidden)
-      assert.equal(document.activeElement, panels[1])
+      assert.equal(document.activeElement, tabs[1])
 
       tabs[1].dispatchEvent(new KeyboardEvent('keydown', {code: 'End', bubbles: true}))
       assert(panels[0].hidden)
       assert(panels[1].hidden)
       assert(!panels[2].hidden)
       assert.equal(document.activeElement, tabs[2])
-      assert.equal(counter, 2)
+      assert.equal(counter, 4)
     })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -219,4 +219,82 @@ describe('tab-container', function () {
       )
     })
   })
+
+  describe('with [role="tablist"][aria-orientation="vertical"]', function () {
+    beforeEach(function () {
+      // eslint-disable-next-line github/no-inner-html
+      document.body.innerHTML = `
+      <tab-container>
+        <div role="tablist" aria-orientation="vertical">
+          <button type="button" role="tab" aria-selected="true">Tab one</button>
+          <button type="button" role="tab">Tab two</button>
+          <button type="button" role="tab">Tab three</button>
+        </div>
+        <div role="tabpanel">
+          Panel 1
+        </div>
+        <div role="tabpanel" hidden>
+          Panel 2
+        </div>
+        <div role="tabpanel" hidden data-tab-container-no-tabstop>
+          Panel 3
+        </div>
+      </tab-container>
+      `
+    })
+
+    it('supports up and down keyboard shortcuts', () => {
+      const tabContainer = document.querySelector('tab-container')
+      const tabs = document.querySelectorAll('button')
+      const panels = document.querySelectorAll('[role="tabpanel"]')
+      let counter = 0
+      tabContainer.addEventListener('tab-container-changed', () => counter++)
+
+      tabs[0].dispatchEvent(new KeyboardEvent('keydown', {code: 'ArrowUp', bubbles: true}))
+      assert(panels[0].hidden)
+      assert(!panels[2].hidden)
+      assert.equal(document.activeElement, tabs[2])
+
+      tabs[0].dispatchEvent(new KeyboardEvent('keydown', {code: 'Home', bubbles: true}))
+      assert(!panels[0].hidden)
+      assert(panels[2].hidden)
+      assert.equal(document.activeElement, tabs[0])
+      assert.equal(counter, 2)
+
+      tabs[0].dispatchEvent(new KeyboardEvent('keydown', {code: 'ArrowDown', bubbles: true}))
+      assert(panels[0].hidden)
+      assert(!panels[1].hidden)
+      assert(panels[2].hidden)
+      assert.equal(document.activeElement, panels[1])
+
+      tabs[1].dispatchEvent(new KeyboardEvent('keydown', {code: 'End', bubbles: true}))
+      assert(panels[0].hidden)
+      assert(panels[1].hidden)
+      assert(!panels[2].hidden)
+      assert.equal(document.activeElement, tabs[2])
+      assert.equal(counter, 2)
+    })
+
+    it('does not supports left and right keyboard shortcuts', () => {
+      const tabContainer = document.querySelector('tab-container')
+      const tabs = document.querySelectorAll('button')
+      const panels = document.querySelectorAll('[role="tabpanel"]')
+      let counter = 0
+      tabContainer.addEventListener('tab-container-changed', () => counter++)
+
+      tabs[0].dispatchEvent(new KeyboardEvent('keydown', {code: 'ArrowLeft', bubbles: true}))
+      assert(!panels[0].hidden)
+      assert(panels[1].hidden)
+      assert(panels[2].hidden)
+      assert.equal(document.activeElement, tabs[0])
+      assert.equal(counter, 0)
+
+      tabs[0].dispatchEvent(new KeyboardEvent('keydown', {code: 'ArrowRight', bubbles: true}))
+      assert(!panels[0].hidden)
+      assert(panels[1].hidden)
+      assert(panels[2].hidden)
+      assert.equal(document.activeElement, tabs[0])
+      assert.equal(counter, 0)
+    })
+  })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -74,6 +74,28 @@ describe('tab-container', function () {
       assert.equal(counter, 2)
     })
 
+    it('does not support down and up keyboard shortcuts', () => {
+      const tabContainer = document.querySelector('tab-container')
+      const tabs = document.querySelectorAll('button')
+      const panels = document.querySelectorAll('[role="tabpanel"]')
+      let counter = 0
+      tabContainer.addEventListener('tab-container-changed', () => counter++)
+
+      tabs[0].dispatchEvent(new KeyboardEvent('keydown', {code: 'ArrowDown', bubbles: true}))
+      assert(!panels[0].hidden)
+      assert(panels[1].hidden)
+      assert(panels[2].hidden)
+      assert.equal(document.activeElement, tabs[0])
+      assert.equal(counter, 0)
+
+      tabs[0].dispatchEvent(new KeyboardEvent('keydown', {code: 'ArrowUp', bubbles: true}))
+      assert(!panels[0].hidden)
+      assert(panels[1].hidden)
+      assert(panels[2].hidden)
+      assert.equal(document.activeElement, tabs[0])
+      assert.equal(counter, 0)
+    })
+
     it('click works and a cancellable `tab-container-change` event is dispatched', function () {
       const tabContainer = document.querySelector('tab-container')
       const tabs = document.querySelectorAll('button')
@@ -275,7 +297,7 @@ describe('tab-container', function () {
       assert.equal(counter, 2)
     })
 
-    it('does not support left and right keyboard shortcuts', () => {
+    it('supports left and right keyboard shortcuts', () => {
       const tabContainer = document.querySelector('tab-container')
       const tabs = document.querySelectorAll('button')
       const panels = document.querySelectorAll('[role="tabpanel"]')
@@ -283,18 +305,28 @@ describe('tab-container', function () {
       tabContainer.addEventListener('tab-container-changed', () => counter++)
 
       tabs[0].dispatchEvent(new KeyboardEvent('keydown', {code: 'ArrowLeft', bubbles: true}))
+      assert(panels[0].hidden)
+      assert(!panels[2].hidden)
+      assert.equal(document.activeElement, tabs[2])
+
+      tabs[0].dispatchEvent(new KeyboardEvent('keydown', {code: 'Home', bubbles: true}))
       assert(!panels[0].hidden)
-      assert(panels[1].hidden)
       assert(panels[2].hidden)
       assert.equal(document.activeElement, tabs[0])
-      assert.equal(counter, 0)
+      assert.equal(counter, 2)
 
       tabs[0].dispatchEvent(new KeyboardEvent('keydown', {code: 'ArrowRight', bubbles: true}))
-      assert(!panels[0].hidden)
-      assert(panels[1].hidden)
+      assert(panels[0].hidden)
+      assert(!panels[1].hidden)
       assert(panels[2].hidden)
-      assert.equal(document.activeElement, tabs[0])
-      assert.equal(counter, 0)
+      assert.equal(document.activeElement, panels[1])
+
+      tabs[1].dispatchEvent(new KeyboardEvent('keydown', {code: 'End', bubbles: true}))
+      assert(panels[0].hidden)
+      assert(panels[1].hidden)
+      assert(!panels[2].hidden)
+      assert.equal(document.activeElement, tabs[2])
+      assert.equal(counter, 2)
     })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -35,7 +35,6 @@ describe('tab-container', function () {
     })
 
     afterEach(function () {
-      // eslint-disable-next-line github/no-inner-html
       document.body.innerHTML = ''
     })
 

--- a/test/test.js
+++ b/test/test.js
@@ -35,6 +35,7 @@ describe('tab-container', function () {
     })
 
     afterEach(function () {
+      // eslint-disable-next-line github/no-inner-html
       document.body.innerHTML = ''
     })
 


### PR DESCRIPTION
When the `[role="tablist"]` element declares
[`[aria-orientation="vertical"]`][aria-orientation], directional
[keyboard navigation changes][keyboard-interaction] from `ArrowRight`
and `ArrowLeft` to `ArrowDown` and `ArrowUp`:

> When a tab list has its `aria-orientation` set to `vertical`:
> * <kbd>Down Arrow</kbd> performs as <kbd>Right Arrow</kbd> is described above.
> * <kbd>Up Arrow</kbd> performs as <kbd>Left Arrow</kbd> is described above.

[aria-orientation]: https://www.w3.org/TR/wai-aria/#aria-orientation
[keyboard-interaction]: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/#keyboard-interaction-21