### PR TITLE
Expose "selectTab" method for programmatic selection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ export default class TabContainerElement extends HTMLElement {
      * Out of bounds index
      */
     if (index > tabs.length - 1) {
-      return
+      throw new Error(`Cannot select tab at index "${index}" as it exceeds the total number of tabs`)
     }
 
     const selectedTab = tabs[index]

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ export default class TabContainerElement extends HTMLElement {
      * Out of bounds index
      */
     if (index > tabs.length - 1) {
-      throw new Error(`Index "${index}" out of bounds`)
+      throw new RangeError(`Index "${index}" out of bounds`)
     }
 
     const selectedTab = tabs[index]

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ export default class TabContainerElement extends HTMLElement {
      * Out of bounds index
      */
     if (index > tabs.length - 1) {
-      throw new Error(`Cannot select tab at index "${index}" as it exceeds the total number of tabs`)
+      throw new Error(`Index "${index}" out of bounds`)
     }
 
     const selectedTab = tabs[index]

--- a/test/test.js
+++ b/test/test.js
@@ -172,10 +172,7 @@ describe('tab-container', function () {
       const tabContainer = document.querySelector('tab-container')
       const panels = document.querySelectorAll('[role="tabpanel"]')
 
-      assert.throws(
-        () => tabContainer.selectTab(3),
-        'Cannot select tab at index "3" as it exceeds the total number of tabs'
-      )
+      assert.throws(() => tabContainer.selectTab(3), 'Index "3" out of bounds')
 
       tabContainer.selectTab(2)
       assert(panels[0].hidden)

--- a/test/test.js
+++ b/test/test.js
@@ -171,15 +171,16 @@ describe('tab-container', function () {
     it('result in noop, when selectTab receives out of bounds index', function () {
       const tabContainer = document.querySelector('tab-container')
       const panels = document.querySelectorAll('[role="tabpanel"]')
-      let counter = 0
-      tabContainer.addEventListener('tab-container-changed', () => {
-        counter++
-      })
 
-      tabContainer.selectTab(20)
-      assert(!panels[0].hidden)
+      assert.throws(
+        () => tabContainer.selectTab(3),
+        'Cannot select tab at index "3" as it exceeds the total number of tabs'
+      )
+
+      tabContainer.selectTab(2)
+      assert(panels[0].hidden)
       assert(panels[1].hidden)
-      assert.equal(counter, 0)
+      assert(!panels[2].hidden)
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -150,6 +150,37 @@ describe('tab-container', function () {
       assert.equal(tabs[1].getAttribute('tabindex'), '0')
       assert.equal(tabs[0].getAttribute('tabindex'), '-1')
     })
+
+    it('`selectTab` works and `tab-container-changed` event is dispatched', function () {
+      const tabContainer = document.querySelector('tab-container')
+      const tabs = document.querySelectorAll('button')
+      const panels = document.querySelectorAll('[role="tabpanel"]')
+      let counter = 0
+      tabContainer.addEventListener('tab-container-changed', event => {
+        counter++
+        assert.equal(event.detail.relatedTarget, panels[1])
+      })
+
+      tabContainer.selectTab(1)
+      assert(panels[0].hidden)
+      assert(!panels[1].hidden)
+      assert.equal(counter, 1)
+      assert.equal(document.activeElement, tabs[1])
+    })
+
+    it('result in noop, when selectTab receives out of bounds index', function () {
+      const tabContainer = document.querySelector('tab-container')
+      const panels = document.querySelectorAll('[role="tabpanel"]')
+      let counter = 0
+      tabContainer.addEventListener('tab-container-changed', () => {
+        counter++
+      })
+
+      tabContainer.selectTab(20)
+      assert(!panels[0].hidden)
+      assert(panels[1].hidden)
+      assert.equal(counter, 0)
+    })
   })
 
   describe('nesting', function () {


### PR DESCRIPTION
This PR moves the `selectTab` method on the `TabContainer` class. Doing so will enable programmatic select of tabs by calling this method. The proposal was shared in this issue https://github.com/github/tab-container-element/issues/55

## Changes

- The `selectTab` method no longer accepts the `tabContainer` instance. It uses `this` implicitly. 
- A conditional has been added to check for out of bounds index (since the method is public now). Right now, I am silently returning when the `index > no of tabs`. Maybe we can raise an exception here? Just wanted feedback on how to proceed with that.

Lemme know if something needs attention. Happy to improve the PR :)