### PR TITLE
fall back HTMLElement in SSR contexts

### DIFF
--- a/src/tab-container-element.ts
+++ b/src/tab-container-element.ts
@@ -1,3 +1,5 @@
+const HTMLElement = globalThis.HTMLElement || (null as unknown as (typeof window)['HTMLElement'])
+
 type IncrementKeyCode = 'ArrowRight' | 'ArrowDown'
 type DecrementKeyCode = 'ArrowUp' | 'ArrowLeft'
 


### PR DESCRIPTION
In SSR contexts `HTMLElement` isn't necessarily available. We can safely extend from `null` which means this element won't throw if it's imported in a library inside of, for e.g. Node.

We did this in https://github.com/github/relative-time-element/pull/257 too. 