### PR TITLE
add TabContainerChange event class

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,30 @@ describe('tab-container', function () {
     })
   })
 
+  describe('events', function () {
+    it('has an onTabContainerChange property for the change event', function () {
+      const el = document.createElement('tab-container')
+      let called = false
+      const listener = () => (called = true)
+      el.onTabContainerChange = listener
+      assert.equal(el.onTabContainerChange, listener)
+      assert.equal(called, false)
+      el.dispatchEvent(new Event('tab-container-change'))
+      assert.equal(called, true)
+    })
+
+    it('has an onTabContainerChanged property for the changed event', function () {
+      const el = document.createElement('tab-container')
+      let called = false
+      const listener = () => (called = true)
+      el.onTabContainerChanged = listener
+      assert.equal(el.onTabContainerChanged, listener)
+      assert.equal(called, false)
+      el.dispatchEvent(new Event('tab-container-changed'))
+      assert.equal(called, true)
+    })
+  })
+
   describe('after tree insertion', function () {
     beforeEach(function () {
       document.body.innerHTML = `
@@ -54,7 +78,8 @@ describe('tab-container', function () {
       let counter = 0
       tabContainer.addEventListener('tab-container-changed', event => {
         counter++
-        assert.equal(event.detail.relatedTarget, panels[1])
+        assert.equal(event.tab, tabs[1])
+        assert.equal(event.panel, panels[1])
       })
 
       tabs[1].click()
@@ -112,7 +137,8 @@ describe('tab-container', function () {
       let counter = 0
       tabContainer.addEventListener('tab-container-change', event => {
         counter++
-        assert.equal(event.detail.relatedTarget, panels[1])
+        assert.equal(event.tab, tabs[1])
+        assert.equal(event.panel, panels[1])
         event.preventDefault()
       })
 
@@ -167,7 +193,8 @@ describe('tab-container', function () {
       let counter = 0
       tabContainer.addEventListener('tab-container-changed', event => {
         counter++
-        assert.equal(event.detail.relatedTarget, panels[1])
+        assert.equal(event.tab, tabs[1])
+        assert.equal(event.panel, panels[1])
       })
 
       tabContainer.selectTab(1)


### PR DESCRIPTION
This adds the `TabContainerChangeEvent`, rather than using `CustomEvent` which is not a best practice, and existed mostly because `Event` used to not be extensible.

Using `TabContainerChangedEvent` we can put properties directly on the event, rather than the awkward `detail` prop.

In addition to this, I've added the `onTabContainerChange` and `onTabContainerChanged` props to the element, which allow the "old school" assignment of the property to add an event listener. This allows frameworks like React to seamlessly use these events too. We did this in https://github.com/github/relative-time-element/pull/246