### PR TITLE
Simplify events

### DIFF
--- a/src/tab-container-element.ts
+++ b/src/tab-container-element.ts
@@ -137,20 +137,12 @@ export class TabContainerElement extends HTMLElement {
   }
 
   #handleClick(event: MouseEvent) {
+    const tab = (event.target as HTMLElement)?.closest?.('[role=tab]')
+    if (!tab) return
     const tabs = getTabs(this)
-
-    if (!(event.target instanceof Element)) return
-    if (event.target.closest(this.tagName) !== this) return
-
-    const tab = event.target.closest('[role="tab"]')
-    if (!(tab instanceof HTMLElement) || !tab.closest('[role="tablist"]')) {
-      return
-    }
-
-    const index = tabs.indexOf(tab)
-    this.selectTab(index)
+    const index = tabs.indexOf(tab as HTMLElement)
+    if (index >= 0) this.selectTab(index)
   }
-
 
   selectTab(index: number): void {
     const tabs = getTabs(this)

--- a/src/tab-container-element.ts
+++ b/src/tab-container-element.ts
@@ -1,8 +1,5 @@
 const HTMLElement = globalThis.HTMLElement || (null as unknown as (typeof window)['HTMLElement'])
 
-type IncrementKeyCode = 'ArrowRight' | 'ArrowDown'
-type DecrementKeyCode = 'ArrowUp' | 'ArrowLeft'
-
 function getTabs(el: TabContainerElement): HTMLElement[] {
   return Array.from(el.querySelectorAll<HTMLElement>('[role="tablist"] [role="tab"]')).filter(
     tab => tab instanceof HTMLElement && tab.closest(el.tagName) === el,
@@ -30,17 +27,6 @@ export class TabContainerChangeEvent extends Event {
   #tab: Element | null = null
   get tab(): Element | null {
     return this.#tab
-  }
-}
-
-function getNavigationKeyCodes(vertical: boolean): [IncrementKeyCode[], DecrementKeyCode[]] {
-  if (vertical) {
-    return [
-      ['ArrowDown', 'ArrowRight'],
-      ['ArrowUp', 'ArrowLeft'],
-    ]
-  } else {
-    return [['ArrowRight'], ['ArrowLeft']]
   }
 }
 
@@ -109,21 +95,21 @@ export class TabContainerElement extends HTMLElement {
   }
 
   #handleKeydown(event: KeyboardEvent) {
-    const target = event.target
-    if (!(target instanceof HTMLElement)) return
-    if (target.closest(this.tagName) !== this) return
-    if (target.getAttribute('role') !== 'tab' && !target.closest('[role="tablist"]')) return
+    const tab = (event.target as HTMLElement)?.closest?.('[role="tab"]')
+    if (!tab) return
     const tabs = getTabs(this)
-    const currentIndex = tabs.indexOf(tabs.find(tab => tab.matches('[aria-selected="true"]'))!)
-    const [incrementKeys, decrementKeys] = getNavigationKeyCodes(
-      target.closest('[role="tablist"]')?.getAttribute('aria-orientation') === 'vertical',
-    )
+    if (!tabs.includes(tab as HTMLElement)) return
 
-    if (incrementKeys.some(code => event.code === code)) {
+    const currentIndex = tabs.indexOf(tabs.find(e => e.matches('[aria-selected="true"]'))!)
+    const vertical = tab.closest('[role="tablist"]')?.getAttribute('aria-orientation') === 'vertical'
+    const prevTab = event.code === 'ArrowLeft' || (vertical && event.code === 'ArrowUp')
+    const nextTab = event.code === 'ArrowRight' || (vertical && event.code === 'ArrowDown')
+
+    if (nextTab) {
       let index = currentIndex + 1
       if (index >= tabs.length) index = 0
       this.selectTab(index)
-    } else if (decrementKeys.some(code => event.code === code)) {
+    } else if (prevTab) {
       let index = currentIndex - 1
       if (index < 0) index = tabs.length - 1
       this.selectTab(index)

--- a/src/tab-container-element.ts
+++ b/src/tab-container-element.ts
@@ -86,6 +86,28 @@ export class TabContainerElement extends HTMLElement {
     }
   }
 
+  connectedCallback(): void {
+    this.addEventListener('keydown', this)
+    this.addEventListener('click', this)
+    for (const tab of getTabs(this)) {
+      if (!tab.hasAttribute('aria-selected')) {
+        tab.setAttribute('aria-selected', 'false')
+      }
+      if (!tab.hasAttribute('tabindex')) {
+        if (tab.getAttribute('aria-selected') === 'true') {
+          tab.setAttribute('tabindex', '0')
+        } else {
+          tab.setAttribute('tabindex', '-1')
+        }
+      }
+    }
+  }
+
+  handleEvent(event: Event) {
+    if (event.type === 'click') return this.#handleClick(event as MouseEvent)
+    if (event.type === 'keydown') return this.#handleKeydown(event as KeyboardEvent)
+  }
+
   #handleKeydown(event: KeyboardEvent) {
     const target = event.target
     if (!(target instanceof HTMLElement)) return
@@ -129,27 +151,6 @@ export class TabContainerElement extends HTMLElement {
     this.selectTab(index)
   }
 
-  connectedCallback(): void {
-    this.addEventListener('keydown', this)
-    this.addEventListener('click', this)
-    for (const tab of getTabs(this)) {
-      if (!tab.hasAttribute('aria-selected')) {
-        tab.setAttribute('aria-selected', 'false')
-      }
-      if (!tab.hasAttribute('tabindex')) {
-        if (tab.getAttribute('aria-selected') === 'true') {
-          tab.setAttribute('tabindex', '0')
-        } else {
-          tab.setAttribute('tabindex', '-1')
-        }
-      }
-    }
-  }
-
-  handleEvent(event: Event) {
-    if (event.type === 'click') return this.#handleClick(event as MouseEvent)
-    if (event.type === 'keydown') return this.#handleKeydown(event as KeyboardEvent)
-  }
 
   selectTab(index: number): void {
     const tabs = getTabs(this)


### PR DESCRIPTION
This simplifies some of the logic around event handlers; prior to this change the event handlers were arrow functions inside `addEventListener` inside the `connectedCallback`, which made it harder to see what was happening in `connectedCallback`. This PR moves them out into their own private functions, instead.

It also simplifies the logic for the functions; they were doing a lot of unnecessary checks, and `handleKeydown` had some logic spread around the codebase in a function declaration. This now moves the logic inline so that the functions read completely, without having to jump around the codebase.