### PR TITLE
Refactor gettabs into private getters

### DIFF
--- a/src/tab-container-element.ts
+++ b/src/tab-container-element.ts
@@ -101,7 +101,7 @@ export class TabContainerElement extends HTMLElement {
   #handleKeydown(event: KeyboardEvent) {
     const tab = (event.target as HTMLElement)?.closest?.('[role="tab"]')
     if (!tab) return
-    const tabs = getTabs(this)
+    const tabs = this.#tabs
     if (!tabs.includes(tab as HTMLElement)) return
 
     const currentIndex = tabs.indexOf(tabs.find(e => e.matches('[aria-selected="true"]'))!)
@@ -129,7 +129,7 @@ export class TabContainerElement extends HTMLElement {
   #handleClick(event: MouseEvent) {
     const tab = (event.target as HTMLElement)?.closest?.('[role=tab]')
     if (!tab) return
-    const tabs = getTabs(this)
+    const tabs = this.#tabs
     const index = tabs.indexOf(tab as HTMLElement)
     if (index >= 0) this.selectTab(index)
   }

--- a/src/tab-container-element.ts
+++ b/src/tab-container-element.ts
@@ -80,8 +80,12 @@ export class TabContainerElement extends HTMLElement {
     }
   }
 
-  get #tabs(): HTMLElement[] {
-    return Array.from(this.querySelectorAll<HTMLElement>('[role="tablist"] [role="tab"]')).filter(
+  get #tabList() {
+    return this.querySelector<HTMLElement>('[role=tablist]')
+  }
+
+  get #tabs() {
+    return Array.from(this.#tabList?.querySelectorAll<HTMLElement>('[role="tab"]') || []).filter(
       tab => tab instanceof HTMLElement && tab.closest(this.tagName) === this,
     )
   }


### PR DESCRIPTION
This refactors out the `getTabs` function, inlining into the class as private field. It also separates the `#tablist` too. 