### PR TITLE
Register event types for better type inference

### DIFF
--- a/src/tab-container-element-define.ts
+++ b/src/tab-container-element-define.ts
@@ -27,6 +27,14 @@ declare global {
       ['tab-container']: JSXBase['span'] & Partial<Omit<TabContainerElement, keyof HTMLElement>>
     }
   }
+  interface GlobalEventHandlersEventMap {
+    'tab-container-change': TabContainerChangeEvent;
+    'tab-container-changed': TabContainerChangeEvent;
+  }
+  interface ElementEventMap {
+    'tab-container-change': TabContainerChangeEvent;
+    'tab-container-changed': TabContainerChangeEvent;
+  }
 }
 
 export default TabContainerElement


### PR DESCRIPTION
This allows typescript to know which kind of event object is passed to listeners for those event names.