### PR TITLE
drop redundant role=presentation from slot element

### DIFF
--- a/src/tab-container-element.ts
+++ b/src/tab-container-element.ts
@@ -184,7 +184,6 @@ export class TabContainerElement extends HTMLElement {
     const panelSlot = document.createElement('slot')
     panelSlot.setAttribute('part', 'panel')
     panelSlot.setAttribute('name', 'panel')
-    panelSlot.setAttribute('role', 'presentation')
     const beforeTabSlot = document.createElement('slot')
     beforeTabSlot.setAttribute('part', 'before-tabs')
     beforeTabSlot.setAttribute('name', 'before-tabs')


### PR DESCRIPTION
A refactoring left in a `role=presentation` on a `slot`, which causes an AXE warning. This fixes that.