### PR TITLE
Return early if tab or panel are undefined

### DIFF
--- a/src/tab-container-element.ts
+++ b/src/tab-container-element.ts
@@ -362,6 +362,9 @@ export class TabContainerElement extends HTMLElement {
     const selectedTab = tabs[index]
     const selectedPanel = panels[index]
 
+    if (!selectedTab) return
+    if (!selectedPanel) return
+
     if (this.#setupComplete) {
       const cancelled = !this.dispatchEvent(
         new TabContainerChangeEvent('tab-container-change', {


### PR DESCRIPTION
We tried to deploy the most recent tab-container-element to dotcom and ran into a `TypeError: Cannot read properties of undefined (reading 'setAttribute')` from [this line](https://github.com/github/tab-container-element/blob/98f5d774717dca50b2bff3af8100890f3481b216/src/tab-container-element.ts#L399). I don't understand how this happened, since we check to see if the index is out of bounds before trying to access the tab or panel arrays. I added some early returns to prevent this error from happening again.