### PR TITLE
bump version to v4.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@github/tab-container-element",
-  "version": "3.1.1",
+  "version": "4.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@github/tab-container-element",
-      "version": "3.1.1",
+      "version": "4.9.0",
       "license": "MIT",
       "devDependencies": {
         "@custom-elements-manifest/analyzer": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@github/tab-container-element",
-  "version": "3.1.1",
+  "version": "4.9.0",
   "description": "Tab container element",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
last released version is 4.8.2 and trying to release a new minor, so bumping to 4.9.0