### PR TITLE
chore: Enhancements to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
-      - run: npm version ${TAG_NAME} --git-tag-version=false
+      - run: npm version ${TAG_NAME} --git-tag-version=false --allow-same-version
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
       - run: npm --ignore-scripts publish --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,12 @@ name: Publish
 on:
   release:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to publish
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -12,7 +18,15 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate tag
+        if: github.event_name == 'workflow_dispatch'
+        run: gh api --silent "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ inputs.tag }}
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -22,5 +36,5 @@ jobs:
       - run: npm test
       - run: npm version ${TAG_NAME} --git-tag-version=false --allow-same-version
         env:
-          TAG_NAME: ${{ github.event.release.tag_name }}
+          TAG_NAME: ${{ github.event.release.tag_name || inputs.tag }}
       - run: npm --ignore-scripts publish --provenance


### PR DESCRIPTION
This pull request updates the `.github/workflows/publish.yml` workflow to add support for manual publishing through the GitHub Actions UI and improves tag handling during the publish process. The main changes are grouped below:

**Manual Workflow Dispatch Support:**

* Added a `workflow_dispatch` trigger with an input for specifying the tag to publish, allowing manual publishing from the GitHub Actions UI.

**Tag Validation and Handling Improvements:**

* Added a step to validate the provided tag exists when running via `workflow_dispatch`, ensuring only valid tags are used for publishing.
* Updated the workflow to use either the release tag (for automatic runs) or the input tag (for manual runs) throughout the checkout and versioning steps, improving flexibility and reliability.
* Allowed publishing with the same version as the tag using the `--allow-same-version` flag in the `npm version` command to prevent failures if the version already matches the tag.